### PR TITLE
Remove fsevents override from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,13 +194,6 @@
     "yaml": "^2.8.1",
     "yocto-queue": "^0.1.0"
   },
-  "overrides": {
-    "fsevents": {
-      "os": [
-        "darwin"
-      ]
-    }
-  },
   "lint-staged": {
     "*.js": [
       "prettier --write",


### PR DESCRIPTION
Deleted the 'overrides' section for 'fsevents' that restricted it to Darwin OS. This simplifies the package configuration.