### PR TITLE
Remove fsevents override from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,12 +205,5 @@
   },
   "directories": {
     "test": "tests"
-  },
-  "overrides": {
-    "fsevents": {
-      "os": [
-        "darwin"
-      ]
-    }
   }
 }


### PR DESCRIPTION
Deleted the 'overrides' section for 'fsevents' in package.json, simplifying configuration and removing OS-specific dependency handling.